### PR TITLE
Merge named entries in groups.

### DIFF
--- a/lib/partial.js
+++ b/lib/partial.js
@@ -1,6 +1,9 @@
 
-import { merge, isArray, map } from 'lodash';
+import { merge, isArray, map, isUndefined, reduce, groupBy } from 'lodash';
 import path from 'path';
+
+// TODO: Why does `Symbol()` not work for this?
+const unique = '___uniq!';
 
 export function inherit(...args) {
 	return merge(
@@ -8,10 +11,20 @@ export function inherit(...args) {
 		(dst, src, key, object, source) => {
 			// Treat entry specially since order is important we can't go just
 			// randomly appending things.
+			// Treat arrays with objects that have the `name` property specially;
+			// entries with identical names will be merged.
 			if (key === 'entry' && src === source.entry) {
 				return src;
 			} else if (isArray(dst) && isArray(src)) {
-				return dst.concat(src);
+				const all = dst.concat(src);
+				const entries = groupBy(
+					all,
+					({ name }) => isUndefined(name) ? unique : name
+				);
+				return reduce(entries, (items, group, name) => {
+					return name !== unique ?
+						items.concat(inherit(...group)) : items.concat(...group)
+				}, []);
 			}
 		}
 	);


### PR DESCRIPTION
If an array has an element with a name, try and merge it with the corresponding named element in the other array. If no such element exists then the behavior is as it was before. This is useful for merging loader configurations.