### PR TITLE
Entries are now semi-mergable.

### DIFF
--- a/lib/partial.js
+++ b/lib/partial.js
@@ -5,6 +5,16 @@ import path from 'path';
 // TODO: Why does `Symbol()` not work for this?
 const unique = '___uniq!';
 
+function entry(dst, src) {
+	if (typeof dst === 'object' && typeof src === 'object') {
+		return {
+			...dst,
+			...src
+		};
+	}
+	return src;
+}
+
 export function inherit(...args) {
 	return merge(
 		...args,
@@ -14,7 +24,7 @@ export function inherit(...args) {
 			// Treat arrays with objects that have the `name` property specially;
 			// entries with identical names will be merged.
 			if (key === 'entry' && src === source.entry) {
-				return src;
+				return entry(dst, src);
 			} else if (isArray(dst) && isArray(src)) {
 				const all = dst.concat(src);
 				const entries = groupBy(


### PR DESCRIPTION
The whole entry object isn't replaced if both are objects – instead source properties overwrite destination properties.