### PR TITLE
Make functions always unique.

### DIFF
--- a/lib/partial.js
+++ b/lib/partial.js
@@ -1,5 +1,13 @@
 
-import { merge, isArray, map, isUndefined, reduce, groupBy } from 'lodash';
+import {
+	merge,
+	isArray,
+	map,
+	isFunction,
+	isUndefined,
+	reduce,
+	groupBy
+} from 'lodash';
 import path from 'path';
 
 // TODO: Why does `Symbol()` not work for this?
@@ -29,7 +37,8 @@ export function inherit(...args) {
 				const all = dst.concat(src);
 				const entries = groupBy(
 					all,
-					({ name }) => isUndefined(name) ? unique : name
+					entry => isFunction(entry) || (entry && isUndefined(entry.name)) ?
+						unique : entry.name
 				);
 				return reduce(entries, (items, group, name) => {
 					return name !== unique ?

--- a/test/spec/partial.spec.js
+++ b/test/spec/partial.spec.js
@@ -58,4 +58,12 @@ describe('partial', () => {
 			.to.have.property('a')
 			.to.have.length(2);
 	});
+
+	it('shoud not overwrite functions', () => {
+		expect(partial(
+			{ foo: [ function() { } ] },
+			{ foo: [ function() { } ] }
+		)).to.have.property('foo')
+			.to.have.length(2);
+	})
 });


### PR DESCRIPTION
Since merging functions is stupid to begin with and anything with the same name (i.e. anonymous functions) previously got merged. Now functions are just left well enough alone.