### PR TITLE
Switch to `babel@6` and remove `require`.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "metalab"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Intelligently merge webpack configuration files.
 ```javascript
 import partial from 'webpack-partial';
 
+import config1 from './my/config/1.webpack.config.js';
+import config2 from './my/config/2.webpack.config.js';
+
 export default partial(
   { entry: './src/input.js' },
-  './my/config/1.webpack.config.js',
-  './my/config/2.webpack.config.js',
+  config1,
+  config2,
   { plugins: [ new MyPlugin() ] },
   // ...
 );

--- a/lib/partial.js
+++ b/lib/partial.js
@@ -51,9 +51,7 @@ export function inherit(...args) {
 
 export function normalize(conf, entry) {
 	if (typeof entry === 'string') {
-		const root = path.dirname(module.parent.filename);
-		const item = require(path.join(root, entry));
-		return normalize(conf, item);
+		throw new TypeError('Cannot `require` partials.');
 	} else if (typeof entry === 'function') {
 		return entry(conf);
 	}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
 	"license": "CC0-1.0",
 	"main": "dist/lib/partial.js",
 	"scripts": {
-		"prepublish:lib": "./node_modules/.bin/babel --stage 0 -d dist/lib lib",
-		"prepublish:test": "./node_modules/.bin/babel --stage 0 -d dist/test test",
+		"prepublish:lib": "./node_modules/.bin/babel -d dist/lib lib",
+		"prepublish:test": "./node_modules/.bin/babel -d dist/test test",
 		"prepublish": "npm run prepublish:lib && npm run prepublish:test",
 		"test": "NODE_ENV=test ./node_modules/.bin/mocha --recursive dist/test/spec"
 	},
@@ -27,7 +27,8 @@
 		"lodash": "^3.10.1"
 	},
 	"devDependencies": {
-		"babel": "^5.8.21",
+		"babel-cli": "^6.0.14",
+		"babel-preset-metalab": "^0.1.1",
 		"mocha": "^2.2.5",
 		"chai": "^3.2.0"
 	}

--- a/test/fixtures/test.js
+++ b/test/fixtures/test.js
@@ -1,3 +1,0 @@
-export default {
-  value: 5
-};

--- a/test/spec/partial.spec.js
+++ b/test/spec/partial.spec.js
@@ -45,9 +45,10 @@ describe('partial', () => {
 			.to.have.property('value', 2);
 	});
 
-	it('should handle strings', () => {
-		expect(partial('../fixtures/test.js'))
-			.to.have.property('value', 5);
+	it('should throw on strings', () => {
+		expect(() => {
+			partial('../fixtures/test.js')
+		}).to.throw(TypeError);
 	});
 
 	it('should overwrite entrypoints', () => {


### PR DESCRIPTION
The module interop for `babel@6` totally breaks using `require`. So we just let consumers import their modules and apply them. It's an extra step sadly, but it is what it is.